### PR TITLE
Add link to protontech repo in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
       "git add"
     ]
   },
-  "homepage": "https://github.com/eface2face/mimemessage.js",
+  "homepage": "https://github.com/ProtonMail/mimemessage.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eface2face/mimemessage.js.git"
+    "url": "git+https://github.com/ProtonMail/mimemessage.js.git"
   },
   "bugs": {
-    "url": "https://github.com/eface2face/mimemessage.js/issues"
+    "url": "https://github.com/ProtonMail/mimemessage.js/issues"
   },
   "dependencies": {
     "debug": "^2.2.0",


### PR DESCRIPTION
Currently the repository link in the NPM package points to the [pre-forked archived version of this package](github.com/eface2face/mimemessage.js); this PR changes the link in the `package.json` to be `https://github.com/ProtonMail/mimemessage.js` for better repository discoverability.